### PR TITLE
Add background mood-model training service

### DIFF
--- a/Nuuz.Application/Services/IMoodModelService.cs
+++ b/Nuuz.Application/Services/IMoodModelService.cs
@@ -1,0 +1,49 @@
+using Nuuz.Domain.Entities;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nuuz.Application.Services
+{
+    public interface IMoodModelService
+    {
+        Task<MoodModel?> GetModelAsync(string userId, string mood, CancellationToken ct = default);
+        Task TrainAsync(string userId, string mood, CancellationToken ct = default);
+        Task RecordEvaluationAsync(string userId, string mood, string articleId, double heuristicScore, double? modelScore, CancellationToken ct = default);
+    }
+
+    public sealed class MoodModel
+    {
+        public double[] Weights { get; init; } = Array.Empty<double>();
+        public double Bias { get; init; }
+
+        public double Predict(Article article)
+        {
+            var f = ExtractFeatures(article);
+            double z = Bias;
+            for (int i = 0; i < f.Length && i < Weights.Length; i++)
+                z += Weights[i] * f[i];
+            return 1.0 / (1.0 + Math.Exp(-z));
+        }
+
+        public static double[] ExtractFeatures(Article a)
+        {
+            return new double[]
+            {
+                a.Arousal ?? 0.5,
+                a.Sentiment ?? 0.0,
+                a.Depth ?? 0.35,
+                a.Conflict ?? 0.25,
+                a.Practicality ?? 0.25,
+                a.Optimism ?? 0.3,
+                a.Novelty ?? 0.3,
+                a.HumanInterest ?? 0.25,
+                a.Hype ?? 0.25,
+                a.Explainer ?? 0.25,
+                a.Analysis ?? 0.25,
+                a.Wholesome ?? 0.25,
+                a.ReadMinutes is > 0 and < 120 ? a.ReadMinutes.Value / 30.0 : 5.0 / 30.0
+            };
+        }
+    }
+}

--- a/Nuuz.Infrastructure/Nuuz.Infrastructure.csproj
+++ b/Nuuz.Infrastructure/Nuuz.Infrastructure.csproj
@@ -12,8 +12,10 @@
     <PackageReference Include="HtmlAgilityPack" Version="1.12.2" />
     <PackageReference Include="jose-jwt" Version="5.2.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.8" />
-	  <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.*" />
-	  <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
+          <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.*" />
+          <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
+    <PackageReference Include="Microsoft.ML" Version="2.0.1" />
+    <PackageReference Include="Microsoft.ML.Mkl.Components" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Nuuz.Infrastructure/Services/MoodModelService.cs
+++ b/Nuuz.Infrastructure/Services/MoodModelService.cs
@@ -1,0 +1,164 @@
+using Google.Cloud.Firestore;
+using Microsoft.ML;
+using Microsoft.ML.Data;
+using Nuuz.Application.Abstraction;
+using Nuuz.Application.Services;
+using Nuuz.Domain.Entities;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nuuz.Infrastructure.Services
+{
+    /// <summary>
+    /// Trains lightweight logistic models per (user,mood) from ArticleFeedback.
+    /// Models are stored in Firestore collection 'MoodModels'.
+    /// </summary>
+    public sealed class MoodModelService : IMoodModelService
+    {
+        private readonly FirestoreDb _db;
+        private readonly IArticleRepository _articles;
+        private readonly MLContext _ml = new();
+
+        public MoodModelService(FirestoreDb db, IArticleRepository articles)
+        {
+            _db = db;
+            _articles = articles;
+        }
+
+        public async Task<MoodModel?> GetModelAsync(string userId, string mood, CancellationToken ct = default)
+        {
+            var docId = $"{userId}_{NormalizeMood(mood)}";
+            var snap = await _db.Collection("MoodModels").Document(docId).GetSnapshotAsync(ct);
+            if (!snap.Exists) return null;
+            var weights = snap.TryGetValue<List<double>>("weights", out var w) ? w : null;
+            var bias = snap.TryGetValue<double>("bias", out var b) ? b : double.NaN;
+            if (weights is null || double.IsNaN(bias)) return null;
+            return new MoodModel { Weights = weights.ToArray(), Bias = b };
+        }
+
+        public async Task TrainAsync(string userId, string mood, CancellationToken ct = default)
+        {
+            var normMood = NormalizeMood(mood);
+            var q = _db.Collection("ArticleFeedback")
+                       .WhereEqualTo("userId", userId)
+                       .WhereEqualTo("mood", normMood)
+                       .OrderByDescending("createdAt")
+                       .Limit(500);
+            var snap = await q.GetSnapshotAsync(ct);
+            var data = new List<Input>();
+            foreach (var d in snap.Documents)
+            {
+                var action = d.TryGetValue<string>("action", out var a) ? a : null;
+                var articleId = d.TryGetValue<string>("articleId", out var aid) ? aid : null;
+                if (string.IsNullOrWhiteSpace(action) || string.IsNullOrWhiteSpace(articleId)) continue;
+                var article = await _articles.GetAsync(articleId);
+                if (article is null) continue;
+                var features = MoodModel.ExtractFeatures(article);
+                data.Add(new Input
+                {
+                    Label = IsPositive(action) ? 1f : 0f,
+                    Arousal = (float)features[0],
+                    Sentiment = (float)features[1],
+                    Depth = (float)features[2],
+                    Conflict = (float)features[3],
+                    Practicality = (float)features[4],
+                    Optimism = (float)features[5],
+                    Novelty = (float)features[6],
+                    Human = (float)features[7],
+                    Hype = (float)features[8],
+                    Explainer = (float)features[9],
+                    Analysis = (float)features[10],
+                    Wholesome = (float)features[11],
+                    ReadMinutes = (float)features[12]
+                });
+            }
+            if (data.Count < 10) return; // not enough samples
+
+            var trainData = _ml.Data.LoadFromEnumerable(data);
+            var pipeline = _ml.Transforms.Concatenate("Features",
+                                    nameof(Input.Arousal),
+                                    nameof(Input.Sentiment),
+                                    nameof(Input.Depth),
+                                    nameof(Input.Conflict),
+                                    nameof(Input.Practicality),
+                                    nameof(Input.Optimism),
+                                    nameof(Input.Novelty),
+                                    nameof(Input.Human),
+                                    nameof(Input.Hype),
+                                    nameof(Input.Explainer),
+                                    nameof(Input.Analysis),
+                                    nameof(Input.Wholesome),
+                                    nameof(Input.ReadMinutes))
+                            .Append(_ml.BinaryClassification.Trainers.SdcaLogisticRegression());
+            var model = pipeline.Fit(trainData);
+            var calibrated = model.LastTransformer.Model as Microsoft.ML.Calibrators.CalibratedModelParametersBase<Microsoft.ML.Trainers.LinearBinaryModelParameters, Microsoft.ML.Calibrators.PlattCalibrator>;
+            if (calibrated is null) return;
+            var linear = calibrated.SubModel;
+            var weights = linear.Weights.ToArray().Select(v => (double)v).ToArray();
+            var bias = linear.Bias;
+            var docRef = _db.Collection("MoodModels").Document($"{userId}_{normMood}");
+            await docRef.SetAsync(new
+            {
+                userId,
+                mood = normMood,
+                weights = weights.ToList(),
+                bias,
+                updatedAt = Timestamp.FromDateTime(DateTime.UtcNow)
+            }, SetOptions.MergeAll, ct);
+        }
+
+        public Task RecordEvaluationAsync(string userId, string mood, string articleId, double heuristicScore, double? modelScore, CancellationToken ct = default)
+        {
+            var docRef = _db.Collection("MoodModelEval").Document();
+            return docRef.SetAsync(new
+            {
+                userId,
+                mood = NormalizeMood(mood),
+                articleId,
+                heuristic = heuristicScore,
+                model = modelScore,
+                createdAt = Timestamp.FromDateTime(DateTime.UtcNow)
+            }, cancellationToken: ct);
+        }
+
+        private static bool IsPositive(string action)
+            => action is "MoreLikeThis" or "GreatExplainer" or "MoreLaunches";
+
+        private static string NormalizeMood(string? m)
+        {
+            var k = (m ?? "").Trim().ToLowerInvariant();
+            return k switch
+            {
+                "calm" => "Calm",
+                "focused" => "Focused",
+                "curious" => "Curious",
+                "hyped" => "Hyped",
+                "meh" => "Meh",
+                "stressed" => "Stressed",
+                "sad" => "Sad",
+                _ => "Calm"
+            };
+        }
+
+        private sealed class Input
+        {
+            [ColumnName("Label")] public float Label { get; set; }
+            public float Arousal { get; set; }
+            public float Sentiment { get; set; }
+            public float Depth { get; set; }
+            public float Conflict { get; set; }
+            public float Practicality { get; set; }
+            public float Optimism { get; set; }
+            public float Novelty { get; set; }
+            public float Human { get; set; }
+            public float Hype { get; set; }
+            public float Explainer { get; set; }
+            public float Analysis { get; set; }
+            public float Wholesome { get; set; }
+            public float ReadMinutes { get; set; }
+        }
+    }
+}

--- a/nuuz.api/Background/MoodModelTrainingService.cs
+++ b/nuuz.api/Background/MoodModelTrainingService.cs
@@ -1,0 +1,67 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Nuuz.Application.Abstraction;
+using Nuuz.Application.Services;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Nuuz.Infrastructure.Services
+{
+    public sealed class MoodModelTrainingService : BackgroundService
+    {
+        private readonly ILogger<MoodModelTrainingService> _log;
+        private readonly IServiceScopeFactory _scopeFactory;
+        private readonly TimeSpan _interval;
+        private static readonly string[] Moods = new[]
+        {
+            "Calm", "Focused", "Curious", "Hyped", "Meh", "Stressed", "Sad"
+        };
+
+        public MoodModelTrainingService(
+            ILogger<MoodModelTrainingService> log,
+            IServiceScopeFactory scopeFactory,
+            IConfiguration cfg)
+        {
+            _log = log;
+            _scopeFactory = scopeFactory;
+            var minutes = Math.Max(1, cfg.GetValue<int?>("ModelTraining:IntervalMinutes") ?? 60);
+            _interval = TimeSpan.FromMinutes(minutes);
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken ct)
+        {
+            _log.LogInformation("MoodModelTrainingService running every {m} minutes", _interval.TotalMinutes);
+            using var timer = new PeriodicTimer(_interval);
+
+            while (await timer.WaitForNextTickAsync(ct))
+            {
+                try
+                {
+                    using var scope = _scopeFactory.CreateScope();
+                    var model = scope.ServiceProvider.GetRequiredService<IMoodModelService>();
+                    var users = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+                    var all = await users.GetAllAsync();
+
+                    foreach (var u in all)
+                    {
+                        if (ct.IsCancellationRequested) break;
+                        foreach (var mood in Moods)
+                        {
+                            await model.TrainAsync(u.FirebaseUid, mood, ct);
+                        }
+                    }
+                }
+                catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+                catch (Exception ex)
+                {
+                    _log.LogError(ex, "Mood model training cycle failed");
+                }
+            }
+
+            _log.LogInformation("MoodModelTrainingService stopped.");
+        }
+    }
+}

--- a/nuuz.api/Program.cs
+++ b/nuuz.api/Program.cs
@@ -86,6 +86,7 @@ builder.Services.AddScoped<IMoodService, MoodService>();
 builder.Services.AddScoped<IInterestMatcher, InterestMatcher>();
 // IMPORTANT: Scoped (not singleton) — it depends on scoped IArticleRepository
 builder.Services.AddScoped<IMoodFeedbackService, MoodFeedbackService>();
+builder.Services.AddScoped<IMoodModelService, MoodModelService>();
 builder.Services.AddScoped<IPulseService, PulseService>();
 builder.Services.AddScoped<IShareService, ShareService>();
 builder.Services.AddScoped<IShareProvider, TwitterShareProvider>();
@@ -129,6 +130,7 @@ builder.Services.AddSingleton<ISparkNotesService, SparkNotesService>();
 
 // ------------------ Background workers ------------------
 builder.Services.AddHostedService<PulseSnapshotService>();
+builder.Services.AddHostedService<MoodModelTrainingService>();
 var ingestionEnabled = builder.Configuration.GetValue<bool>("Ingestion:Enabled");
 if (builder.Environment.IsDevelopment() && ingestionEnabled)
 {

--- a/nuuz.api/appsettings.json
+++ b/nuuz.api/appsettings.json
@@ -13,6 +13,9 @@
   "Seed": {
     "Interests": false
   },
+  "ModelTraining": {
+    "IntervalMinutes": 60
+  },
   "Ingestion": {
     "Enabled": true,
     "IntervalMinutes": 60,


### PR DESCRIPTION
## Summary
- train per-user mood models on a schedule with new `MoodModelTrainingService`
- register the training background service
- add configuration for training interval

## Testing
- `dotnet build nuuz.api/Nuuz.sln`
- `dotnet test nuuz.api/Nuuz.sln`


------
https://chatgpt.com/codex/tasks/task_e_68aaa2fad910832881aeae73b48bce82